### PR TITLE
nodeaffinity: support multiple values for NotIn in matchFields

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4993,10 +4993,15 @@ func ValidateNodeFieldSelectorRequirement(req core.NodeSelectorRequirement, fldP
 	allErrs := field.ErrorList{}
 
 	switch req.Operator {
-	case core.NodeSelectorOpIn, core.NodeSelectorOpNotIn:
+	case core.NodeSelectorOpIn:
 		if len(req.Values) != 1 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("values"),
-				"must be only one value when `operator` is 'In' or 'NotIn' for node field selector"))
+				"must be only one value when `operator` is 'In' for node field selector"))
+		}
+	case core.NodeSelectorOpNotIn:
+		if len(req.Values) == 0 {
+			allErrs = append(allErrs, field.Required(fldPath.Child("values"),
+				"must have at least one value when `operator` is 'NotIn' for node field selector"))
 		}
 	default:
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("operator"), req.Operator, "not a valid selector operator"))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -11516,6 +11516,24 @@ func TestValidatePod(t *testing.T) {
 				}),
 			),
 		},
+		"invalid node field selector requirement in node affinity, no values for field selector": {
+			expectedError: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].values",
+			spec: *podtest.MakePod("123",
+				podtest.SetAffinity(&core.Affinity{
+					NodeAffinity: &core.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &core.NodeSelector{
+							NodeSelectorTerms: []core.NodeSelectorTerm{{
+								MatchFields: []core.NodeSelectorRequirement{{
+									Key:      "metadata.name",
+									Operator: core.NodeSelectorOpNotIn,
+									Values:   []string{},
+								}},
+							}},
+						},
+					},
+				}),
+			),
+		},
 		"invalid node field selector requirement in node affinity, invalid operator": {
 			expectedError: "spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchFields[0].operator",
 			spec: *podtest.MakePod("123",

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity.go
@@ -275,10 +275,14 @@ func nodeSelectorRequirementsAsFieldSelector(nsr []v1.NodeSelectorRequirement, p
 			}
 
 		case v1.NodeSelectorOpNotIn:
-			if len(expr.Values) != 1 {
-				errs = append(errs, field.Invalid(p.Child("values"), expr.Values, "must have one element"))
+			if len(expr.Values) == 0 {
+				errs = append(errs, field.Required(p.Child("values"), "must have at least one element"))
 			} else {
-				selectors = append(selectors, fields.OneTermNotEqualSelector(expr.Key, expr.Values[0]))
+				// NotIn with multiple values is supported because it translates to AND:
+				// key NotIn [v1, v2, v3] -> key!=v1 AND key!=v2 AND key!=v3
+				for _, value := range expr.Values {
+					selectors = append(selectors, fields.OneTermNotEqualSelector(expr.Key, value))
+				}
 			}
 
 		default:

--- a/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/corev1/nodeaffinity/nodeaffinity_test.go
@@ -145,6 +145,34 @@ func TestNodeSelectorMatch(t *testing.T) {
 			node:      &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "host_1"}},
 			wantMatch: true,
 		},
+		{
+			name: "field selector NotIn with multiple values - node matches",
+			nodeSelector: v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchFields: []v1.NodeSelectorRequirement{{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpNotIn,
+						Values:   []string{"excluded_1", "excluded_2", "excluded_3"},
+					}},
+				},
+			}},
+			node:      &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "host_1"}},
+			wantMatch: true,
+		},
+		{
+			name: "field selector NotIn with multiple values - node does not match",
+			nodeSelector: v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
+				{
+					MatchFields: []v1.NodeSelectorRequirement{{
+						Key:      "metadata.name",
+						Operator: v1.NodeSelectorOpNotIn,
+						Values:   []string{"excluded_1", "host_1", "excluded_3"},
+					}},
+				},
+			}},
+			node:      &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "host_1"}},
+			wantMatch: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
